### PR TITLE
Get test coverage close to 100%

### DIFF
--- a/generate-coverage.sh
+++ b/generate-coverage.sh
@@ -16,11 +16,23 @@ phantomjs \
   test/coverage.html \
   spec '{"hooks": "mocha-phantomjs-istanbul", "coverageFile": "coverage/coverage.json"}'
 
-# Convert the JSON coverage to LCOV for coveralls.
-istanbul report --include coverage/*.json lcovonly
+if [ $CI ]; then
+  # Convert the JSON coverage to LCOV for coveralls.
+  istanbul report --include coverage/*.json lcovonly
 
-# Post the results to coveralls.io
-set +o errexit
-cat coverage/lcov.info | coveralls
+  # Post the results to coveralls.io
+  set +o errexit
+  cat coverage/lcov.info | coveralls
 
-echo ''  # reset exit code -- failure to post coverage shouldn't be an error.
+  echo ''  # reset exit code -- failure to post coverage shouldn't be an error.
+
+else
+  # Convert the JSON coverage to HTML for viewing
+  istanbul report --include coverage/*.json html
+  set +x
+
+  echo 'To browse coverage, run:'
+  echo
+  echo '  open coverage/index.html'
+  echo
+fi

--- a/src/data-canvas.js
+++ b/src/data-canvas.js
@@ -161,7 +161,7 @@ RecordingContext.reset = function() {
 RecordingContext.recorderForCanvas = function(canvas) {
   var recorders = RecordingContext.recorders;
   if (recorders == null) {
-    throw 'You can only call recorderForCanvas after RecordingContext.recordAll()';
+    throw 'You must call RecordingContext.recordAll() before using other RecordingContext static methods';
   }
   for (var i = 0; i < recorders.length; i++) {
     var r = recorders[i];
@@ -176,9 +176,6 @@ RecordingContext.recorderForCanvas = function(canvas) {
  * This is useful when you have a test div and several canvases.
  */
 RecordingContext.recorderForSelector = function(div, selector) {
-  if (RecordingContext.recorders == null) {
-    throw 'You can only call recorderForSelector after RecordingContext.recordAll()';
-  }
   var canvas = div.querySelector(selector + ' canvas') || div.querySelector(selector);
   if (!canvas) {
     throw 'Unable to find a canvas matching ' + selector;
@@ -269,6 +266,7 @@ function ClickTrackingContext(ctx, px, py) {
   };
 
   // These are (most of) the canvas methods which draw something.
+  // TODO: would it make sense to purge existing hits covered by this?
   this.clearRect = function(x, y, w, h) { };
 
   this.fillRect = function(x, y, w, h) {
@@ -305,6 +303,7 @@ var exports = {
 };
 
 if (typeof(module) !== 'undefined') {
+  /* istanbul ignore next */
   module.exports = exports;
 } else {
   window.dataCanvas = exports;


### PR DESCRIPTION
PhantomJS 1.x doesn't support `isPointInStroke` and I was unable to find a polyfill. So Coveralls won't show 100% coverage until Travis-CI updates to Phantom 2.
