### PR TITLE
Preserve calls/this.calls aliasing

### DIFF
--- a/src/data-canvas.js
+++ b/src/data-canvas.js
@@ -114,7 +114,8 @@ function RecordingContext(ctx) {
       recordingDrawImage.apply(ctx, arguments);
     } else {
       ctx.drawImage.apply(ctx, arguments);
-      this.calls = this.calls.concat(transformedCalls(recorder.calls, arguments));
+      calls = calls.concat(transformedCalls(recorder.calls, arguments));
+      this.calls = calls;
     }
   }
 }

--- a/test/data-canvas-test.js
+++ b/test/data-canvas-test.js
@@ -444,6 +444,23 @@ describe('data-canvas', function() {
             [['drawImage', image, 0, 0]]);
         expect(dtx.callsOf('fillRect')).to.deep.equal([]);
       });
+
+      // Regression test for #13
+      it('should record calls after drawImage', function() {
+        var image = makeOffscreenImage();
+        var dtx = dataCanvas.getDataContext(canvas);
+        dtx.clearRect(0, 0, 200, 50);
+        dtx.drawImage(image, 0, 0);
+        dtx.fillRect(20, 10, 100, 40);
+
+        expect(dtx.calls).to.have.length(5);
+        expect(dtx.drawnObjects()).to.deep.equal(['A']);
+        expect(dtx.callsOf('clearRect')).to.deep.equal([['clearRect', 0, 0, 200, 50]]);
+        expect(dtx.callsOf('fillRect')).to.deep.equal([
+            ['fillRect', 0, 0, 50, 50],
+            ['fillRect', 20, 10, 100, 40]
+        ]);
+      });
     });
   });
 });


### PR DESCRIPTION
Fixes #13 

Maybe I should _only_ use `this.calls`.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/data-canvas/14)

<!-- Reviewable:end -->
